### PR TITLE
Enumize acces levels second

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -27,6 +27,16 @@ class User < ApplicationRecord
 
   paginates_per 50
 
+  enum access_level_int: {
+    employee:       0,
+    manager_light: 10,
+    hr_light:      20,
+    manager:       30,
+    hr:            40,
+    account_owner: 50,
+    admin:         60
+  }
+
   include PgSearch::Model
   pg_search_scope :search_users,
     against: [ :firstname, :lastname, :email ],


### PR DESCRIPTION
@bricechapuis second branch to handle once https://github.com/Seven2018/booklet.byseven.co/pull/366 is merged and deploy, after I run this script in the production rails console (+ tests scripts not copied here):
```
mapping = {
  'Super Admin'     => 60,
  'Account Owner'   => 50,
  'HR'              => 40,
  'Manager'         => 30,
  'HR-light'        => 20,
  'Manager-light'   => 10,
  'Employee'        => 0
}

User.all.each do |user|
  user.update access_level_int: mapping[user.access_level]
end
```